### PR TITLE
test(e2e): add minio integration and resume download spec

### DIFF
--- a/apps/web/e2e/download.spec.ts
+++ b/apps/web/e2e/download.spec.ts
@@ -9,9 +9,6 @@ test.describe("Resume Download Flow", () => {
     const downloadButton = page.locator('a[aria-label="Download Resume"]');
     await expect(downloadButton).toBeVisible();
     
-    // Start waiting for the download event BEFORE clicking
-    const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
-    
     // Click the button to trigger the modal and API generation
     await downloadButton.click();
     
@@ -19,15 +16,18 @@ test.describe("Resume Download Flow", () => {
     const modalHeading = page.getByText("Preparing", { exact: false });
     await expect(modalHeading).toBeVisible();
     
+    // Wait for the generation to complete and the direct link to appear
+    const directDownloadLink = page.getByText("Download File Directly");
+    await expect(directDownloadLink).toBeVisible({ timeout: 15000 });
+    
+    // Now setup the download listener BEFORE clicking the direct link
+    const downloadPromise = page.waitForEvent('download');
+    await directDownloadLink.click();
+    
     // Wait for the actual file download to complete
     const download = await downloadPromise;
     
     // Verify it downloaded a PDF file
     expect(download.suggestedFilename()).toMatch(/\.pdf$/i);
-    
-    // Check that the download modal eventually shows success or closes
-    const successText = page.getByText("Ready for Download!", { exact: false });
-    // It might close or show this text depending on how the frontend handles the auto-download.
-    // The test passes if the file was downloaded via the browser.
   });
 });

--- a/apps/web/e2e/download.spec.ts
+++ b/apps/web/e2e/download.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Resume Download Flow", () => {
+  test("should successfully generate and download resume PDF", async ({ page }) => {
+    // Navigate to the resume page. The database is seeded by seed.js so the resume exists.
+    await page.goto("/resume");
+
+    // Wait for the Download Resume button to appear
+    const downloadButton = page.locator('a[aria-label="Download Resume"]');
+    await expect(downloadButton).toBeVisible();
+    
+    // Start waiting for the download event BEFORE clicking
+    const downloadPromise = page.waitForEvent('download', { timeout: 15000 });
+    
+    // Click the button to trigger the modal and API generation
+    await downloadButton.click();
+    
+    // Wait for the download progress modal to appear
+    const modalHeading = page.getByText("Preparing", { exact: false });
+    await expect(modalHeading).toBeVisible();
+    
+    // Wait for the actual file download to complete
+    const download = await downloadPromise;
+    
+    // Verify it downloaded a PDF file
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/i);
+    
+    // Check that the download modal eventually shows success or closes
+    const successText = page.getByText("Ready for Download!", { exact: false });
+    // It might close or show this text depending on how the frontend handles the auto-download.
+    // The test passes if the file was downloaded via the browser.
+  });
+});

--- a/apps/web/src/components/ContactLinks.tsx
+++ b/apps/web/src/components/ContactLinks.tsx
@@ -81,7 +81,7 @@ export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactL
   }
 
   // Resume download
-  if (downloadUrl && (contact.linkIds?.resume || contact.linkIds?.Resume)) {
+  if (downloadUrl) {
     items.push({
       href: downloadUrl,
       Icon: DownloadIcon,
@@ -89,7 +89,7 @@ export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactL
       label: 'Download Resume',
       download: true,
       onClick: (e) => { e.preventDefault(); setIsModalOpen(true); },
-      linkId: contact.linkIds?.resume || contact.linkIds?.Resume,
+      linkId: contact.linkIds?.resume || contact.linkIds?.Resume || 'resume',
     });
   }
 

--- a/apps/web/src/components/DownloadProgressModal.tsx
+++ b/apps/web/src/components/DownloadProgressModal.tsx
@@ -153,6 +153,7 @@ export const DownloadProgressModal = ({
                   strokeWidth="6"
                   fill="transparent"
                   strokeDasharray={301.6}
+                  initial={{ strokeDashoffset: 301.6 }}
                   animate={{
                     strokeDashoffset: 301.6 - (301.6 * progress) / 100,
                   }}

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -40,7 +40,7 @@ services:
       DB_NAME: portfolio
       DB_USER: user
       DB_PASSWORD: e2e_test_password
-      S3_ENDPOINT: http://localhost:9000
+      S3_ENDPOINT: http://minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: minioadminpassword
       S3_BUCKET_NAME: portfolio-media
@@ -49,3 +49,18 @@ services:
         condition: service_healthy
     # No container-side healthcheck — the aspnet slim image has no curl/wget.
     # Readiness is polled from the runner host in the CI "Wait for API" step.
+
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadminpassword
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+
+volumes:
+  minio_data:


### PR DESCRIPTION


<!-- AI_SUMMARY_START -->
### 🤖 AI-Generated Summary

This pull request introduces a new end-to-end (E2E) test for the resume download functionality, ensuring the entire flow from clicking the download button to verifying the PDF download works as expected. It also includes several improvements to the frontend components and crucial infrastructure changes for the E2E environment.

### Changelog:

*   **New Feature:** Added `download.spec.ts` E2E test using Playwright to validate the resume generation and download process.
*   **Refactor:** Simplified the condition for displaying the resume download link in `ContactLinks.tsx` and added a fallback `linkId` of `'resume'` for better robustness.
*   **Enhancement:** Improved the `DownloadProgressModal.tsx` animation by correctly initializing the `strokeDashoffset` for the progress circle, providing a smoother visual experience.
*   **Infrastructure:** Integrated a MinIO service into `docker-compose.e2e.yml` to provide S3-compatible storage for E2E tests. Corrected the `S3_ENDPOINT` configuration for the API service to `http://minio:9000` to ensure proper communication within the Docker Compose network.

*Generated by Google Gemini (gemini-2.5-flash)*

<!-- AI_SUMMARY_END -->