### PR TITLE
feat(analytics): add Instagram, fix cascade delete log loss, and add …

### DIFF
--- a/apps/api/Directory.Packages.props
+++ b/apps/api/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
     <PackageVersion Include="Bogus" Version="35.6.5" />

--- a/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
+++ b/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
@@ -25,10 +25,16 @@ public class AnalyticsService(
     {
         // Safety guard: silently discard clicks for link IDs that don't exist in the DB.
         // The frontend is responsible for sending the correct DB GUID via data-link-id.
-        var linkExists = await resumeRepository.LinkExistsAsync(log.LinkId);
-        if (!linkExists)
+        if (log.LinkId.HasValue)
         {
-            return;
+            var link = await resumeRepository.GetLinkByIdAsync(log.LinkId.Value);
+            if (link == null)
+            {
+                return;
+            }
+            
+            log.TargetUrl = link.Url;
+            log.LinkTypeName = link.LinkType?.Name;
         }
 
         await repository.LogLinkClickAsync(log);

--- a/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
+++ b/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
@@ -37,8 +37,8 @@ public class AnalyticsService(
                 return;
             }
             
-            log.TargetUrl = link.Url?.Replace("\r", "")?.Replace("\n", "");
-            log.LinkTypeName = link.LinkType?.Name?.Replace("\r", "")?.Replace("\n", "");
+            log.TargetUrl = System.Text.RegularExpressions.Regex.Replace(link.Url ?? "", @"[\r\n\t]", "");
+            log.LinkTypeName = System.Text.RegularExpressions.Regex.Replace(link.LinkType?.Name ?? "", @"[\r\n\t]", "");
         }
 
         await repository.LogLinkClickAsync(log);

--- a/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
+++ b/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
@@ -37,8 +37,8 @@ public class AnalyticsService(
                 return;
             }
             
-            log.TargetUrl = link.Url;
-            log.LinkTypeName = link.LinkType?.Name;
+            log.TargetUrl = link.Url?.Replace("\r", "")?.Replace("\n", "");
+            log.LinkTypeName = link.LinkType?.Name?.Replace("\r", "")?.Replace("\n", "");
         }
 
         await repository.LogLinkClickAsync(log);

--- a/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
+++ b/apps/api/src/Portfolio.Application/Analytics/Services/AnalyticsService.cs
@@ -2,6 +2,8 @@ using Portfolio.Application.Analytics.Repositories;
 using Portfolio.Application.Resume.Repositories;
 using Portfolio.Domain.Analytics;
 
+using Microsoft.Extensions.Logging;
+
 namespace Portfolio.Application.Analytics.Services;
 
 public interface IAnalyticsService
@@ -13,7 +15,8 @@ public interface IAnalyticsService
 
 public class AnalyticsService(
     IAnalyticsRepository repository,
-    IResumeRepository resumeRepository) : IAnalyticsService
+    IResumeRepository resumeRepository,
+    ILogger<AnalyticsService> logger) : IAnalyticsService
 {
     public async Task LogPageViewAsync(PageViewLog log)
     {
@@ -30,6 +33,7 @@ public class AnalyticsService(
             var link = await resumeRepository.GetLinkByIdAsync(log.LinkId.Value);
             if (link == null)
             {
+                logger.LogWarning("Link click received for missing LinkId {LinkId}. This may indicate a desync between the frontend and backend.", log.LinkId);
                 return;
             }
             

--- a/apps/api/src/Portfolio.Application/Portfolio.Application.csproj
+++ b/apps/api/src/Portfolio.Application/Portfolio.Application.csproj
@@ -17,6 +17,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
       <PackageReference Include="QuestPDF" />
     </ItemGroup>
 

--- a/apps/api/src/Portfolio.Domain/Analytics/LinkClickLog.cs
+++ b/apps/api/src/Portfolio.Domain/Analytics/LinkClickLog.cs
@@ -5,7 +5,9 @@ namespace Portfolio.Domain.Analytics;
 public class LinkClickLog
 {
     public Guid Id { get; set; } = Guid.CreateVersion7();
-    public Guid LinkId { get; set; }
+    public Guid? LinkId { get; set; }
+    public string? TargetUrl { get; set; }
+    public string? LinkTypeName { get; set; }
     public DateTime ClickedAt { get; set; } = DateTime.UtcNow;
     public string? IpAddress { get; set; }
     public string? UserAgent { get; set; }

--- a/apps/api/src/Portfolio.Infrastructure/Database/Configuration/LinkClickLogConfiguration.cs
+++ b/apps/api/src/Portfolio.Infrastructure/Database/Configuration/LinkClickLogConfiguration.cs
@@ -28,10 +28,16 @@ public class LinkClickLogConfiguration : IEntityTypeConfiguration<LinkClickLog>
         builder.Property(c => c.City)
             .HasMaxLength(100);
 
+        builder.Property(c => c.TargetUrl)
+            .HasMaxLength(2000);
+            
+        builder.Property(c => c.LinkTypeName)
+            .HasMaxLength(50);
+
         // Relationships
         builder.HasOne(c => c.Link)
             .WithMany(l => l.Clicks)
             .HasForeignKey(c => c.LinkId)
-            .OnDelete(DeleteBehavior.Cascade);
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/apps/api/src/Portfolio.Infrastructure/Migrations/20260611181613_FixAnalyticsCascadeDelete.Designer.cs
+++ b/apps/api/src/Portfolio.Infrastructure/Migrations/20260611181613_FixAnalyticsCascadeDelete.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Portfolio.Infrastructure.Database.Contexts;
@@ -11,9 +12,11 @@ using Portfolio.Infrastructure.Database.Contexts;
 namespace Portfolio.Infrastructure.Migrations
 {
     [DbContext(typeof(PortfolioDbContext))]
-    partial class PortfolioDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611181613_FixAnalyticsCascadeDelete")]
+    partial class FixAnalyticsCascadeDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Portfolio.Infrastructure/Migrations/20260611181613_FixAnalyticsCascadeDelete.cs
+++ b/apps/api/src/Portfolio.Infrastructure/Migrations/20260611181613_FixAnalyticsCascadeDelete.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Portfolio.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixAnalyticsCascadeDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_LinkClickLogs_ResumeProfileLinks_LinkId",
+                table: "LinkClickLogs");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "LinkId",
+                table: "LinkClickLogs",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AddColumn<string>(
+                name: "LinkTypeName",
+                table: "LinkClickLogs",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TargetUrl",
+                table: "LinkClickLogs",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_LinkClickLogs_ResumeProfileLinks_LinkId",
+                table: "LinkClickLogs",
+                column: "LinkId",
+                principalTable: "ResumeProfileLinks",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_LinkClickLogs_ResumeProfileLinks_LinkId",
+                table: "LinkClickLogs");
+
+            migrationBuilder.DropColumn(
+                name: "LinkTypeName",
+                table: "LinkClickLogs");
+
+            migrationBuilder.DropColumn(
+                name: "TargetUrl",
+                table: "LinkClickLogs");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "LinkId",
+                table: "LinkClickLogs",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_LinkClickLogs_ResumeProfileLinks_LinkId",
+                table: "LinkClickLogs",
+                column: "LinkId",
+                principalTable: "ResumeProfileLinks",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/apps/api/src/Portfolio.Tests/Unit/AnalyticsServiceTests.cs
+++ b/apps/api/src/Portfolio.Tests/Unit/AnalyticsServiceTests.cs
@@ -39,12 +39,20 @@ public class AnalyticsServiceTests
         // Arrange
         var linkId = Guid.NewGuid();
         var log = new LinkClickLog { Id = Guid.NewGuid(), LinkId = linkId };
-        _resumeRepositoryMock.LinkExistsAsync(linkId).Returns(true);
+        var mockLink = new Portfolio.Domain.Resume.ResumeProfileLink 
+        { 
+            Id = linkId, 
+            Url = "https://example.com", 
+            LinkType = new Portfolio.Domain.Resume.ResumeProfileLinkType { Name = "Twitter" } 
+        };
+        _resumeRepositoryMock.GetLinkByIdAsync(linkId).Returns(mockLink);
 
         // Act
         await _service.LogLinkClickAsync(log);
 
         // Assert
+        log.TargetUrl.ShouldBe("https://example.com");
+        log.LinkTypeName.ShouldBe("Twitter");
         await _repositoryMock.Received(1).LogLinkClickAsync(log);
         await _repositoryMock.Received(1).SaveChangesAsync();
     }
@@ -83,7 +91,7 @@ public class AnalyticsServiceTests
         // Arrange
         var linkId = Guid.NewGuid();
         var log = new LinkClickLog { Id = Guid.NewGuid(), LinkId = linkId };
-        _resumeRepositoryMock.LinkExistsAsync(linkId).Returns(false);
+        _resumeRepositoryMock.GetLinkByIdAsync(linkId).Returns((Portfolio.Domain.Resume.ResumeProfileLink?)null);
 
         // Act
         await _service.LogLinkClickAsync(log);

--- a/apps/api/src/Portfolio.Tests/Unit/AnalyticsServiceTests.cs
+++ b/apps/api/src/Portfolio.Tests/Unit/AnalyticsServiceTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Portfolio.Application.Analytics.Repositories;
 using Portfolio.Application.Analytics.Services;
@@ -12,11 +13,12 @@ public class AnalyticsServiceTests
 {
     private readonly IAnalyticsRepository _repositoryMock = Substitute.For<IAnalyticsRepository>();
     private readonly IResumeRepository _resumeRepositoryMock = Substitute.For<IResumeRepository>();
+    private readonly ILogger<AnalyticsService> _loggerMock = Substitute.For<ILogger<AnalyticsService>>();
     private readonly AnalyticsService _service;
 
     public AnalyticsServiceTests()
     {
-        _service = new AnalyticsService(_repositoryMock, _resumeRepositoryMock);
+        _service = new AnalyticsService(_repositoryMock, _resumeRepositoryMock, _loggerMock);
     }
 
     [Fact]

--- a/apps/web/e2e/admin.spec.ts
+++ b/apps/web/e2e/admin.spec.ts
@@ -18,6 +18,12 @@ test.describe('Admin Control Panel', () => {
     await expect(page.locator('text=Views Over Time')).toBeVisible({ timeout: 10000 });
     const chartOrFallback = page.locator('.recharts-responsive-container').or(page.getByText('Not enough data to display chart')).first();
     await expect(chartOrFallback).toBeVisible();
+
+    // Verify toggle for Unique/Total Views
+    const toggleButton = page.locator('button', { hasText: /Showing: Unique Visitors/i });
+    await expect(toggleButton).toBeVisible();
+    await toggleButton.click();
+    await expect(page.locator('button', { hasText: /Showing: Total Views/i })).toBeVisible();
   });
 
   test('should load the audit logs page', async ({ page }) => {
@@ -61,6 +67,7 @@ test.describe('Admin Control Panel', () => {
     await page.locator('#title').fill('Automated Test Engineer');
     await page.locator('#intro').fill('This profile was fully generated and validated by an E2E Playwright test.');
     await page.locator('#email').fill('playwright-test@ajx.codes');
+    await page.locator('#instagramVal').fill('https://instagram.com/playwright');
 
     // 4. Add a Job
     await page.locator('button:has-text("Add Job")').click();

--- a/apps/web/playwright-results.json
+++ b/apps/web/playwright-results.json
@@ -11,7 +11,7 @@
     "grepInvert": null,
     "maxFailures": 0,
     "metadata": {
-      "actualWorkers": 5
+      "actualWorkers": 8
     },
     "preserveOutput": "always",
     "projects": [
@@ -20,7 +20,7 @@
         "repeatEach": 1,
         "retries": 0,
         "metadata": {
-          "actualWorkers": 5
+          "actualWorkers": 8
         },
         "id": "chromium",
         "name": "chromium",
@@ -64,6 +64,125 @@
   },
   "suites": [
     {
+      "title": "admin.spec.ts",
+      "file": "admin.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Admin Control Panel",
+          "file": "admin.spec.ts",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "should load the traffic telemetry page",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 4061,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.343Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d4043a9dd1ab94463227-a5ff8bcacadd04fc7db7",
+              "file": "admin.spec.ts",
+              "line": 4,
+              "column": 7
+            },
+            {
+              "title": "should load the audit logs page",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 3037,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.402Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d4043a9dd1ab94463227-c527a7c92fd629bab49d",
+              "file": "admin.spec.ts",
+              "line": 29,
+              "column": 7
+            },
+            {
+              "title": "should create, save, activate, and view a new resume profile",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 2,
+                      "parallelIndex": 2,
+                      "status": "passed",
+                      "duration": 6690,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.335Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d4043a9dd1ab94463227-4c315fd48d1371760832",
+              "file": "admin.spec.ts",
+              "line": 53,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
       "title": "analytics.spec.ts",
       "file": "analytics.spec.ts",
       "column": 0,
@@ -73,7 +192,7 @@
         {
           "title": "Traffic Attribution Analytics",
           "file": "analytics.spec.ts",
-          "line": 5,
+          "line": 6,
           "column": 6,
           "specs": [
             {
@@ -89,15 +208,15 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 0,
-                      "parallelIndex": 0,
+                      "workerIndex": 3,
+                      "parallelIndex": 3,
                       "status": "passed",
-                      "duration": 1792,
+                      "duration": 2445,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-06-10T16:51:58.198Z",
+                      "startTime": "2026-06-11T18:39:12.428Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -107,7 +226,7 @@
               ],
               "id": "634c82c6846b68aa8d60-84234bfb66f7d085b58b",
               "file": "analytics.spec.ts",
-              "line": 45,
+              "line": 48,
               "column": 7
             },
             {
@@ -123,15 +242,15 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 1,
-                      "parallelIndex": 1,
+                      "workerIndex": 4,
+                      "parallelIndex": 4,
                       "status": "passed",
-                      "duration": 1956,
+                      "duration": 2569,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-06-10T16:51:58.192Z",
+                      "startTime": "2026-06-11T18:39:12.360Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -141,7 +260,143 @@
               ],
               "id": "634c82c6846b68aa8d60-357cf8a7f637f335eda1",
               "file": "analytics.spec.ts",
-              "line": 63,
+              "line": 68,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "blog.spec.ts",
+      "file": "blog.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Blog Page",
+          "file": "blog.spec.ts",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "should load the blog page and render empty state",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 5,
+                      "parallelIndex": 5,
+                      "status": "passed",
+                      "duration": 2243,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.290Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "a378e5ce917615b4b643-b350d436cff0d7fee633",
+              "file": "blog.spec.ts",
+              "line": 4,
+              "column": 7
+            },
+            {
+              "title": "should navigate to blog post detail page when a post is clicked",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 6,
+                      "parallelIndex": 6,
+                      "status": "passed",
+                      "duration": 2081,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.322Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "a378e5ce917615b4b643-7192517a962fe4af05c9",
+              "file": "blog.spec.ts",
+              "line": 18,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "download.spec.ts",
+      "file": "download.spec.ts",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Resume Download Flow",
+          "file": "download.spec.ts",
+          "line": 3,
+          "column": 6,
+          "specs": [
+            {
+              "title": "should successfully generate and download resume PDF",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 7,
+                      "parallelIndex": 7,
+                      "status": "passed",
+                      "duration": 4528,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:12.301Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "29cf83cb0d33ef5cc857-b46633c50006fc3043b6",
+              "file": "download.spec.ts",
+              "line": 4,
               "column": 7
             }
           ]
@@ -174,15 +429,15 @@
                   "projectName": "chromium",
                   "results": [
                     {
-                      "workerIndex": 2,
-                      "parallelIndex": 2,
+                      "workerIndex": 6,
+                      "parallelIndex": 6,
                       "status": "passed",
-                      "duration": 1307,
+                      "duration": 1514,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-06-10T16:51:58.190Z",
+                      "startTime": "2026-06-11T18:39:14.570Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -193,6 +448,40 @@
               "id": "d318381359a9b96acb1e-fbe43f818ed637226a05",
               "file": "home.spec.ts",
               "line": 4,
+              "column": 7
+            },
+            {
+              "title": "should cycle themes using the ThemeSwitcher button",
+              "ok": true,
+              "tags": [],
+              "tests": [
+                {
+                  "timeout": 30000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "chromium",
+                  "projectName": "chromium",
+                  "results": [
+                    {
+                      "workerIndex": 5,
+                      "parallelIndex": 5,
+                      "status": "passed",
+                      "duration": 1744,
+                      "errors": [],
+                      "stdout": [],
+                      "stderr": [],
+                      "retry": 0,
+                      "startTime": "2026-06-11T18:39:14.690Z",
+                      "annotations": [],
+                      "attachments": []
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "d318381359a9b96acb1e-d5e83be3df7ba7e8b947",
+              "file": "home.spec.ts",
+              "line": 14,
               "column": 7
             }
           ]
@@ -228,12 +517,12 @@
                       "workerIndex": 3,
                       "parallelIndex": 3,
                       "status": "passed",
-                      "duration": 2476,
+                      "duration": 2318,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-06-10T16:51:58.207Z",
+                      "startTime": "2026-06-11T18:39:15.047Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -243,7 +532,7 @@
               ],
               "id": "2352191a150b5313c38a-865157ab54e20925dacc",
               "file": "resume.spec.ts",
-              "line": 64,
+              "line": 44,
               "column": 7
             },
             {
@@ -262,12 +551,12 @@
                       "workerIndex": 4,
                       "parallelIndex": 4,
                       "status": "passed",
-                      "duration": 2945,
+                      "duration": 2690,
                       "errors": [],
                       "stdout": [],
                       "stderr": [],
                       "retry": 0,
-                      "startTime": "2026-06-10T16:51:58.209Z",
+                      "startTime": "2026-06-11T18:39:15.105Z",
                       "annotations": [],
                       "attachments": []
                     }
@@ -277,7 +566,7 @@
               ],
               "id": "2352191a150b5313c38a-352d524a6b800dd59279",
               "file": "resume.spec.ts",
-              "line": 82,
+              "line": 62,
               "column": 7
             }
           ]
@@ -287,9 +576,9 @@
   ],
   "errors": [],
   "stats": {
-    "startTime": "2026-06-10T16:51:55.097Z",
-    "duration": 6347.959000000001,
-    "expected": 5,
+    "startTime": "2026-06-11T18:39:07.145Z",
+    "duration": 12252.801000000001,
+    "expected": 12,
     "skipped": 0,
     "unexpected": 0,
     "flaky": 0

--- a/apps/web/src/app/admin/analytics/page.tsx
+++ b/apps/web/src/app/admin/analytics/page.tsx
@@ -25,6 +25,7 @@ interface AnalyticsSummary {
     userAgent: string | null;
     country: string | null;
     city: string | null;
+    ipAddress: string | null;
   }>;
   recentLinkClicks: Array<{
     id: string;
@@ -51,16 +52,29 @@ export default function AnalyticsPage() {
   const [summary, setSummary] = useState<AnalyticsSummary | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
+  const [showTotalViews, setShowTotalViews] = useState(false);
 
   const viewsByDate = useMemo(() => {
     if (!summary) return [];
-    const counts: Record<string, number> = {};
-    [...summary.recentPageViews].reverse().forEach(view => {
-      const date = new Date(view.viewedAt).toLocaleDateString([], { month: 'short', day: 'numeric' });
-      counts[date] = (counts[date] || 0) + 1;
-    });
-    return Object.entries(counts).map(([date, count]) => ({ date, count }));
-  }, [summary]);
+    
+    if (showTotalViews) {
+      const counts: Record<string, number> = {};
+      [...summary.recentPageViews].reverse().forEach(view => {
+        const date = new Date(view.viewedAt).toLocaleDateString([], { month: 'short', day: 'numeric' });
+        counts[date] = (counts[date] || 0) + 1;
+      });
+      return Object.entries(counts).map(([date, count]) => ({ date, count }));
+    } else {
+      const counts: Record<string, Set<string>> = {};
+      [...summary.recentPageViews].reverse().forEach(view => {
+        const date = new Date(view.viewedAt).toLocaleDateString([], { month: 'short', day: 'numeric' });
+        if (!counts[date]) counts[date] = new Set<string>();
+        // Fallback to ID if no IP is present to still count it as unique (though it shouldn't happen)
+        counts[date].add(view.ipAddress || view.id);
+      });
+      return Object.entries(counts).map(([date, set]) => ({ date, count: set.size }));
+    }
+  }, [summary, showTotalViews]);
 
   const clicksByLink = useMemo(() => {
     if (!summary) return [];
@@ -198,10 +212,20 @@ export default function AnalyticsPage() {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
             {/* Page Views Chart */}
             <div className="terminal-card p-6 rounded-xl space-y-4">
-              <h3 className="font-bold text-sm text-foreground/90 flex items-center gap-2">
-                <TrendingUp className="w-4 h-4 text-primary" />
-                Views Over Time
-              </h3>
+              <div className="flex items-center justify-between">
+                <h3 className="font-bold text-sm text-foreground/90 flex items-center gap-2">
+                  <TrendingUp className="w-4 h-4 text-primary" />
+                  Views Over Time
+                </h3>
+                <button
+                  type="button"
+                  onClick={() => setShowTotalViews(!showTotalViews)}
+                  className="px-2.5 py-1 text-[10px] font-bold rounded-md bg-primary/10 border border-primary/20 hover:bg-primary/20 text-primary transition-colors uppercase tracking-wider flex items-center gap-1.5"
+                >
+                  <Eye className="w-3 h-3" />
+                  {showTotalViews ? "Showing: Total Views" : "Showing: Unique Visitors"}
+                </button>
+              </div>
               <div className="h-64 w-full mt-4">
                 {viewsByDate.length > 0 ? (
                   <ResponsiveContainer width="100%" height="100%">

--- a/apps/web/src/app/admin/analytics/page.tsx
+++ b/apps/web/src/app/admin/analytics/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import Link from "next/link";
 import { supabase } from "@/lib/supabaseBrowser";
 import { 
@@ -53,6 +53,8 @@ export default function AnalyticsPage() {
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
   const [showTotalViews, setShowTotalViews] = useState(false);
+
+  const toggleViews = useCallback(() => setShowTotalViews(prev => !prev), []);
 
   const viewsByDate = useMemo(() => {
     if (!summary) return [];
@@ -219,7 +221,7 @@ export default function AnalyticsPage() {
                 </h3>
                 <button
                   type="button"
-                  onClick={() => setShowTotalViews(!showTotalViews)}
+                  onClick={toggleViews}
                   className="px-2.5 py-1 text-[10px] font-bold rounded-md bg-primary/10 border border-primary/20 hover:bg-primary/20 text-primary transition-colors uppercase tracking-wider flex items-center gap-1.5"
                 >
                   <Eye className="w-3 h-3" />

--- a/apps/web/src/app/admin/analytics/page.tsx
+++ b/apps/web/src/app/admin/analytics/page.tsx
@@ -228,6 +228,12 @@ export default function AnalyticsPage() {
                   {showTotalViews ? "Showing: Total Views" : "Showing: Unique Visitors"}
                 </button>
               </div>
+              {!showTotalViews && (
+                <p className="text-[10px] text-muted-foreground italic flex items-center gap-1 mt-2">
+                  <AlertCircle className="w-3 h-3" />
+                  Fallback IDs are used if IP address is missing.
+                </p>
+              )}
               <div className="h-64 w-full mt-4">
                 {viewsByDate.length > 0 ? (
                   <ResponsiveContainer width="100%" height="100%">

--- a/apps/web/src/app/admin/resume/form/page.tsx
+++ b/apps/web/src/app/admin/resume/form/page.tsx
@@ -22,7 +22,8 @@ import {
   Briefcase,
   X,
   ChevronDown,
-  ChevronUp
+  ChevronUp,
+  Instagram
 } from "lucide-react";
 
 import { useResumeForm, ExperienceItem } from "@/hooks/useResumeForm";
@@ -56,6 +57,8 @@ function ResumeFormContent() {
     setCalendar,
     githubVal,
     setGithubVal,
+    instagramVal,
+    setInstagramVal,
     experiences,
     availableCategories,
     newSkillNameMap,
@@ -414,6 +417,21 @@ function ResumeFormContent() {
                 onChange={(e) => setGithubVal(e.target.value)}
                 className="w-full px-4 py-2 bg-primary/5 border border-primary/20 rounded-md focus:outline-none focus:ring-1 focus:ring-primary/40 transition-all text-xs"
                 placeholder="https://github.com/username"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="instagramVal" className="flex items-center gap-2 text-[10px] font-bold uppercase tracking-wider mb-2">
+                <Instagram className="w-3.5 h-3.5 text-muted-foreground" />
+                Instagram Profile URL
+              </label>
+              <input
+                id="instagramVal"
+                type="text"
+                value={instagramVal}
+                onChange={(e) => setInstagramVal(e.target.value)}
+                className="w-full px-4 py-2 bg-primary/5 border border-primary/20 rounded-md focus:outline-none focus:ring-1 focus:ring-primary/40 transition-all text-xs"
+                placeholder="https://instagram.com/username"
               />
             </div>
           </div>

--- a/apps/web/src/components/ContactLinks.tsx
+++ b/apps/web/src/components/ContactLinks.tsx
@@ -6,6 +6,7 @@ import {
   CalendarIcon,
   DownloadIcon,
   InstagramIcon,
+  LinkIcon,
 } from '@/components/icons';
 import { type ContactInfo } from '@/lib/data';
 import { DownloadProgressModal } from '@/components/DownloadProgressModal';
@@ -18,91 +19,63 @@ interface ContactLinksProps {
   downloadUrl?: string;
 }
 
+const iconMap: Record<string, React.ComponentType<{ className: string }>> = {
+  email: MailIcon,
+  linkedin: LinkedInIcon,
+  github: GitHubIcon,
+  calendar: CalendarIcon,
+  instagram: InstagramIcon,
+};
+
+const formatText = (type: string, url: string) => {
+  switch (type.toLowerCase()) {
+    case 'email': return url.replace('mailto:', '');
+    case 'linkedin': return url.replace(/https?:\/\/(www\.)?linkedin\.com\/in\//i, '').replace(/\/$/, '');
+    case 'github': return url.replace(/https?:\/\/(www\.)?github\.com\//i, '').replace(/\/$/, '');
+    case 'instagram': return url.replace(/https?:\/\/(www\.)?instagram\.com\//i, '').replace(/\/$/, '');
+    case 'calendar': return "Let's Chat";
+    default: return url.replace(/^https?:\/\//i, '').replace(/\/$/, '');
+  }
+};
+
+const formatHref = (type: string, url: string) => {
+  if (type.toLowerCase() === 'email') {
+    return url.includes('@') && !url.startsWith('mailto:') ? `mailto:${url}` : url;
+  }
+  return url.startsWith('http') || url.startsWith('mailto:') ? url : `https://${url}`;
+};
+
 export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactLinksProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Defensive check
-  if (!contact) {
-    console.error("ContactLinks component was rendered without the required 'contact' prop.");
+  if (!contact || !contact.links) {
+    console.error("ContactLinks component was rendered without the required 'contact.links' array.");
     return null;
   }
 
-  const items: Array<{
-    href: string;
-    Icon: React.ComponentType<{ className: string }>;
-    text: string;
-    label: string;
-    download?: boolean;
-    onClick?: (e: React.MouseEvent) => void;
-    linkId: string;
-  }> = [];
+  const regularLinks = contact.links.filter(l => l.type.toLowerCase() !== 'resume');
 
-  // Email
-  if (contact.email && (contact.linkIds?.email || contact.linkIds?.Email)) {
-    items.push({
-      href: contact.email.includes('@') && !contact.email.startsWith('mailto:') ? `mailto:${contact.email}` : contact.email,
-      Icon: MailIcon,
-      text: contact.email.replace('mailto:', ''),
-      label: `Email ${contact.email}`,
-      linkId: contact.linkIds?.email || contact.linkIds?.Email,
-    });
-  }
-
-  // LinkedIn
-  if (contact.linkedin && (contact.linkIds?.linkedin || contact.linkIds?.LinkedIn)) {
-    items.push({
-      href: contact.linkedin.startsWith('http') ? contact.linkedin : `https://${contact.linkedin}`,
-      Icon: LinkedInIcon,
-      text: contact.linkedin.replace(/https?:\/\/(www\.)?linkedin\.com\/in\//, '').replace(/\/$/, ''),
-      label: 'LinkedIn Profile',
-      linkId: contact.linkIds?.linkedin || contact.linkIds?.LinkedIn,
-    });
-  }
-
-  // GitHub
-  if (contact.github && (contact.linkIds?.github || contact.linkIds?.GitHub)) {
-    items.push({
-      href: contact.github.startsWith('http') ? contact.github : `https://${contact.github}`,
-      Icon: GitHubIcon,
-      text: contact.github.replace(/https?:\/\/(www\.)?github\.com\//, '').replace(/\/$/, ''),
-      label: 'GitHub Profile',
-      linkId: contact.linkIds?.github || contact.linkIds?.GitHub,
-    });
-  }
-
-  // Calendar
-  if (contact.calendar && (contact.linkIds?.calendar || contact.linkIds?.Calendar)) {
-    items.push({
-      href: contact.calendar,
-      Icon: CalendarIcon,
-      text: "Let's Chat",
-      label: 'Schedule a meeting',
-      linkId: contact.linkIds?.calendar || contact.linkIds?.Calendar,
-    });
-  }
-
-  // Instagram
-  if (contact.instagram && (contact.linkIds?.instagram || contact.linkIds?.Instagram)) {
-    items.push({
-      href: contact.instagram.startsWith('http') ? contact.instagram : `https://${contact.instagram}`,
-      Icon: InstagramIcon,
-      text: contact.instagram.replace(/https?:\/\/(www\.)?instagram\.com\//, '').replace(/\/$/, ''),
-      label: 'Instagram Profile',
-      linkId: contact.linkIds?.instagram || contact.linkIds?.Instagram,
-    });
-  }
+  const items: any[] = regularLinks.map(link => ({
+    href: formatHref(link.type, link.url),
+    Icon: iconMap[link.type.toLowerCase()] || LinkIcon,
+    text: formatText(link.type, link.url),
+    label: `${link.type.charAt(0).toUpperCase() + link.type.slice(1)} Link`,
+    linkId: link.linkId,
+  }));
 
   // Resume download
   if (downloadUrl) {
+    const resumeLink = contact.links.find(l => l.type.toLowerCase() === 'resume');
     items.push({
       href: downloadUrl,
       Icon: DownloadIcon,
       text: "Resume",
       label: 'Download Resume',
       download: true,
-      onClick: (e) => { e.preventDefault(); setIsModalOpen(true); },
-      linkId: contact.linkIds?.resume || contact.linkIds?.Resume || 'resume',
-    });
+      onClick: (e: React.MouseEvent) => { e.preventDefault(); setIsModalOpen(true); },
+      linkId: resumeLink?.linkId || 'resume',
+    } as any);
   }
 
   return (

--- a/apps/web/src/components/ContactLinks.tsx
+++ b/apps/web/src/components/ContactLinks.tsx
@@ -85,7 +85,7 @@ export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactL
       download: true,
       onClick: (e: React.MouseEvent) => { e.preventDefault(); setIsModalOpen(true); },
       linkId: resumeLink?.linkId || 'resume',
-    } as any);
+    });
   }
 
   return (

--- a/apps/web/src/components/ContactLinks.tsx
+++ b/apps/web/src/components/ContactLinks.tsx
@@ -56,7 +56,17 @@ export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactL
 
   const regularLinks = contact.links.filter(l => l.type.toLowerCase() !== 'resume');
 
-  const items: any[] = regularLinks.map(link => ({
+  interface ContactLinkItem {
+    href: string;
+    Icon: React.ElementType;
+    text: string;
+    label: string;
+    linkId?: string;
+    download?: boolean;
+    onClick?: (e: React.MouseEvent) => void;
+  }
+
+  const items: ContactLinkItem[] = regularLinks.map(link => ({
     href: formatHref(link.type, link.url),
     Icon: iconMap[link.type.toLowerCase()] || LinkIcon,
     text: formatText(link.type, link.url),

--- a/apps/web/src/components/ContactLinks.tsx
+++ b/apps/web/src/components/ContactLinks.tsx
@@ -5,6 +5,7 @@ import {
   GitHubIcon,
   CalendarIcon,
   DownloadIcon,
+  InstagramIcon,
 } from '@/components/icons';
 import { type ContactInfo } from '@/lib/data';
 import { DownloadProgressModal } from '@/components/DownloadProgressModal';
@@ -77,6 +78,17 @@ export const ContactLinks = ({ contact, showText = true, downloadUrl }: ContactL
       text: "Let's Chat",
       label: 'Schedule a meeting',
       linkId: contact.linkIds?.calendar || contact.linkIds?.Calendar,
+    });
+  }
+
+  // Instagram
+  if (contact.instagram && (contact.linkIds?.instagram || contact.linkIds?.Instagram)) {
+    items.push({
+      href: contact.instagram.startsWith('http') ? contact.instagram : `https://${contact.instagram}`,
+      Icon: InstagramIcon,
+      text: contact.instagram.replace(/https?:\/\/(www\.)?instagram\.com\//, '').replace(/\/$/, ''),
+      label: 'Instagram Profile',
+      linkId: contact.linkIds?.instagram || contact.linkIds?.Instagram,
     });
   }
 

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -85,7 +85,7 @@ export const Header = ({ name, contact, downloadUrl, photoUrlLight, photoUrlDark
           >
             <Avatar size={40} altText={name} photoUrlLight={photoUrlLight} photoUrlDark={photoUrlDark} />
             <span className="hidden sm:flex items-center gap-1 text-lg font-bold font-mono tracking-tight text-primary">
-              {getGithubUsername(contact.github) || name.toLowerCase().replace(/\s+/g, '')}
+              {getGithubUsername(contact.links?.find(l => l.type.toLowerCase() === 'github')?.url) || name.toLowerCase().replace(/\s+/g, '')}
             </span>
           </Link>
         </div>

--- a/apps/web/src/components/__tests__/Header.test.tsx
+++ b/apps/web/src/components/__tests__/Header.test.tsx
@@ -47,12 +47,10 @@ window.IntersectionObserver = MockIntersectionObserver as any;
 
 describe('Header Component', () => {
   const mockContact = {
-    email: 'me@ajx.codes',
-    phone: '',
-    website: '',
-    linkedin: '',
-    calendar: '',
-    github: 'https://github.com/ajxcodes'
+    links: [
+      { type: 'email', url: 'me@ajx.codes' },
+      { type: 'github', url: 'https://github.com/ajxcodes' }
+    ]
   };
 
   beforeEach(() => {
@@ -87,13 +85,13 @@ describe('Header Component', () => {
   });
 
   it('falls back to lowercase name without spaces if no github is available', () => {
-    const contactNoGithub = { ...mockContact, github: '' };
+    const contactNoGithub = { links: [] };
     render(<Header name="Alex Jones" contact={contactNoGithub} />);
     expect(screen.getByText('alexjones')).toBeInTheDocument();
   });
 
   it('falls back to lowercase name without spaces if github url is invalid', () => {
-    const contactInvalidGithub = { ...mockContact, github: 'https://othersite.com' };
+    const contactInvalidGithub = { links: [{ type: 'github', url: 'https://othersite.com' }] };
     render(<Header name="Alex Jones" contact={contactInvalidGithub} />);
     expect(screen.getByText('https://othersite.com')).toBeInTheDocument();
   });

--- a/apps/web/src/components/icons.tsx
+++ b/apps/web/src/components/icons.tsx
@@ -12,6 +12,10 @@ export const GitHubIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" /><path d="M9 18c-4.51 2-5-2-7-2" /></svg>
 );
 
+export const InstagramIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}><rect width="20" height="20" x="2" y="2" rx="5" ry="5"/><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"/><line x1="17.5" x2="17.51" y1="6.5" y2="6.5"/></svg>
+);
+
 export const DownloadIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><polyline points="7 10 12 15 17 10" /><line x1="12" x2="12" y1="15" y2="3" /></svg>
 );

--- a/apps/web/src/hooks/__tests__/useTrafficTracker.test.tsx
+++ b/apps/web/src/hooks/__tests__/useTrafficTracker.test.tsx
@@ -105,6 +105,72 @@ describe('useTrafficTracker Hook', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it('fetches geo details asynchronously in development mode', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.NEXT_PUBLIC_GEOIP_SERVICE_URL = 'http://localhost:8080/geo';
+    
+    // 1st fetch: GeoIP, 2nd fetch: /api/analytics/views
+    (global.fetch as jest.Mock).mockImplementation((url) => {
+      if (url === 'http://localhost:8080/geo') {
+        return Promise.resolve({
+          json: async () => ({ country_name: 'Canada', city: 'Calgary' })
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<TestTrackerComponent />);
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('http://localhost:8080/geo', expect.any(Object));
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/analytics/views'),
+      expect.objectContaining({
+        body: expect.stringContaining('"Country":"Canada"')
+      })
+    );
+
+    // Test the sync cache path now that it's in sessionStorage
+    const { rerender } = render(<TestTrackerComponent />);
+    mockUsePathname.mockReturnValue('/another-path');
+    rerender(<TestTrackerComponent />);
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  it('handles geo details fetch failure gracefully', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    process.env.NEXT_PUBLIC_GEOIP_SERVICE_URL = 'http://localhost:8080/geo';
+    
+    (global.fetch as jest.Mock).mockImplementation((url) => {
+      if (url === 'http://localhost:8080/geo') {
+        return Promise.reject(new Error('Geo fetch failed'));
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<TestTrackerComponent />);
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    // Should still log the page view but with null country/city
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/analytics/views'),
+      expect.objectContaining({
+        body: expect.stringContaining('"Country":null')
+      })
+    );
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
   it('tracks outbound link clicks only when data-link-id is present', () => {
     render(<TestTrackerComponent />);
     

--- a/apps/web/src/hooks/commandStrategies.ts
+++ b/apps/web/src/hooks/commandStrategies.ts
@@ -70,12 +70,18 @@ export const catHandler: CommandHandler = {
     }
     const target = arg.toLowerCase();
     if (target === 'contact') {
-      return [
-        { type: 'output', text: `email    : ${context.resume.contact?.email || 'N/A'}` },
-        { type: 'output', text: `github   : ${context.resume.contact?.github || 'N/A'}` },
-        { type: 'output', text: `linkedin : ${context.resume.contact?.linkedin || 'N/A'}` },
-        { type: 'output', text: `calendar : ${context.resume.contact?.calendar || 'N/A'}` }
-      ];
+      const output: TerminalHistoryItem[] = [];
+      if (context.resume.contact?.links) {
+        context.resume.contact.links.forEach(link => {
+          if (link.type.toLowerCase() !== 'resume') {
+            output.push({ type: 'output', text: `${link.type.padEnd(8)} : ${link.url}` });
+          }
+        });
+      }
+      if (output.length === 0) {
+        output.push({ type: 'output', text: 'No contact information available.' });
+      }
+      return output;
     }
     if (target.startsWith('blog/')) {
       const slug = arg.substring(5);

--- a/apps/web/src/hooks/useResumeForm.ts
+++ b/apps/web/src/hooks/useResumeForm.ts
@@ -47,6 +47,7 @@ export function useResumeForm() {
   const [linkedinVal, setLinkedinVal] = useState("");
   const [calendar, setCalendar] = useState("");
   const [githubVal, setGithubVal] = useState("");
+  const [instagramVal, setInstagramVal] = useState("");
 
   // Experiences & categories
   const [experiences, setExperiences] = useState<ExperienceItem[]>([]);
@@ -83,6 +84,7 @@ export function useResumeForm() {
               if (key === "linkedin") setLinkedinVal(l.url || "");
               if (key === "calendar") setCalendar(l.url || "");
               if (key === "github") setGithubVal(l.url || "");
+              if (key === "instagram") setInstagramVal(l.url || "");
             });
           }
 
@@ -330,6 +332,7 @@ export function useResumeForm() {
     if (linkedinVal) linksList.push({ linkTypeName: "LinkedIn", linkTypeKey: "linkedin", url: linkedinVal });
     if (calendar) linksList.push({ linkTypeName: "Calendar", linkTypeKey: "calendar", url: calendar });
     if (githubVal) linksList.push({ linkTypeName: "GitHub", linkTypeKey: "github", url: githubVal });
+    if (instagramVal) linksList.push({ linkTypeName: "Instagram", linkTypeKey: "instagram", url: instagramVal });
 
     const payload = {
       name,
@@ -396,6 +399,8 @@ export function useResumeForm() {
     setCalendar,
     githubVal,
     setGithubVal,
+    instagramVal,
+    setInstagramVal,
     experiences,
     availableCategories,
     newSkillNameMap,

--- a/apps/web/src/hooks/useTerminalShell.test.ts
+++ b/apps/web/src/hooks/useTerminalShell.test.ts
@@ -44,10 +44,12 @@ describe('useTerminalShell Hook and Strategies', () => {
       }
     ],
     contact: {
-      email: 'me@ajx.codes',
-      github: 'github.com/ajxcodes',
-      linkedin: 'linkedin.com/in/alvinjorrel',
-      calendar: 'cal.com/ajx'
+      links: [
+        { type: 'email', url: 'me@ajx.codes' },
+        { type: 'github', url: 'github.com/ajxcodes' },
+        { type: 'linkedin', url: 'linkedin.com/in/alvinjorrel' },
+        { type: 'calendar', url: 'cal.com/ajx' }
+      ]
     },
     skills: [],
     projects: [],
@@ -179,13 +181,13 @@ describe('useTerminalShell Hook and Strategies', () => {
     });
 
     it('should handle missing contact fields gracefully', () => {
-      const emptyResume = { ...mockResume, contact: {} };
+      const emptyResume = { ...mockResume, contact: { links: [] } };
       const { result } = renderHook(() => useTerminalShell(mockBlogPosts, emptyResume));
       act(() => {
         result.current.executeCommand('cat contact');
       });
       const historyLength = result.current.history.length;
-      expect(result.current.history[historyLength - 4].text).toBe('email    : N/A');
+      expect(result.current.history[historyLength - 1].text).toBe('No contact information available.');
     });
 
     it('should show blog details if found', () => {

--- a/apps/web/src/lib/__tests__/data.test.ts
+++ b/apps/web/src/lib/__tests__/data.test.ts
@@ -93,8 +93,8 @@ describe('data access API fetch handlers', () => {
     expect(data.personalInfo.name).toBe('Test Name');
     expect(data.personalInfo.title).toBe('Test Title');
     expect(data.personalInfo.photoUrlLight).toBe('/light.png');
-    expect(data.resume.contact.github).toBe('github.com/test');
-    expect(data.resume.contact.email).toBe('test@email.com');
+    expect(data.resume.contact.links.find(l => l.type === 'github')?.url).toBe('github.com/test');
+    expect(data.resume.contact.links.find(l => l.type === 'email')?.url).toBe('test@email.com');
 
     // Verify display order sorting
     expect(data.resume.experience[0].company).toBe('Company A');
@@ -118,7 +118,7 @@ describe('data access API fetch handlers', () => {
     
     // Checks that fallback contains default static details
     expect(data.personalInfo.name).toBe('Alvin Jorrel Pascual');
-    expect(data.resume.contact.github).toBe('github.com/ajxcodes');
+    expect(data.resume.contact.links.find(l => l.type === 'github')?.url).toBe('github.com/ajxcodes');
   });
 
   it('falls back to default configurations when responses are not ok', async () => {

--- a/apps/web/src/lib/data.ts
+++ b/apps/web/src/lib/data.ts
@@ -7,14 +7,14 @@ export interface PersonalInfo {
   photoUrlDark?: string;
 }
 
+export interface ProfileLink {
+  linkId?: string;
+  type: string;
+  url: string;
+}
+
 export interface ContactInfo {
-  email: string;
-  phone: string;
-  website: string;
-  linkedin: string;
-  calendar: string;
-  github: string;
-  linkIds?: Record<string, string>;
+  links: ProfileLink[];
 }
 
 export interface SkillGroup {
@@ -93,12 +93,12 @@ const defaultData: PortfolioData = {
   },
   resume: {
     contact: {
-      email: "me@ajx.codes",
-      phone: "",
-      website: "",
-      linkedin: "linkedin.com/in/alvinjorrel",
-      calendar: "https://calendar.app.google/waCKdLPyQZeYYUEx8",
-      github: "github.com/ajxcodes",
+      links: [
+        { type: "email", url: "me@ajx.codes" },
+        { type: "linkedin", url: "linkedin.com/in/alvinjorrel" },
+        { type: "calendar", url: "https://calendar.app.google/waCKdLPyQZeYYUEx8" },
+        { type: "github", url: "github.com/ajxcodes" }
+      ]
     },
     summary: {
       lead: "A senior software engineer and technical leader with over a decade of experience in the .NET ecosystem.",
@@ -159,20 +159,20 @@ export const getResumeData = cache(async (): Promise<{ personalInfo: PersonalInf
       portfolioData.resume.photoUrlDark = active.photoUrlDark;
 
       if (active.links && active.links.length > 0) {
-        const contactLinks: Record<string, string> = {};
-        const linkIds: Record<string, string> = {};
+        const contactLinks: ProfileLink[] = [];
         active.links.forEach((l: any) => {
           const key = l.linkType?.keyIdentifier || l.linkType?.name?.toLowerCase();
           if (key) {
-            contactLinks[key] = l.url;
-            linkIds[key] = l.id;
+            contactLinks.push({
+              linkId: l.id,
+              type: key,
+              url: l.url
+            });
           }
         });
-        portfolioData.resume.contact = {
-          ...portfolioData.resume.contact,
-          ...contactLinks,
-          linkIds,
-        };
+        portfolioData.resume.contact = { links: contactLinks };
+      } else {
+        portfolioData.resume.contact = { links: [] };
       }
 
       portfolioData.resume.downloadUrl = `${apiUrl}/api/resume/active/download`;

--- a/ci-summary-report.md
+++ b/ci-summary-report.md
@@ -1,0 +1,17 @@
+# 🚀 CI/CD Test & Coverage Summary
+
+### 📊 Test Execution Results
+
+| Test Suite | Total Tests | Passed | Failed | Skipped | Status |
+| :--- | :---: | :---: | :---: | :---: | :---: |
+| **Backend (.NET)** | - | - | - | - | 🚫 Not Run / Skipped |
+| **Frontend (Jest)** | - | - | - | - | 🚫 Not Run / Skipped |
+| **End-to-End (Playwright)** | 12 | 12 | 0 | 0 | ✅ PASSED |
+
+### 📉 Code Coverage Report
+
+| Component | Line Coverage | Branch Coverage | Details |
+| :--- | :---: | :---: | :--- |
+| **Backend (.NET)** | - | - | 🚫 No Coverage Data |
+| **Frontend (Jest)** | 98.10% | 83.25% | 671/684 statements, 328/394 conditionals |
+


### PR DESCRIPTION


<!-- AI_SUMMARY_START -->
### 🤖 AI-Generated Summary

This PR introduces several enhancements to the portfolio analytics and resume management systems:

- **Analytics Improvements**: Added `TargetUrl` and `LinkTypeName` to `LinkClickLog` to capture context at the time of click. Updated `AnalyticsService` to sanitize these fields and log warnings for missing links.
- **Database Schema**: Updated `LinkClickLog` to use `SetNull` on `LinkId` deletion, preventing data loss in analytics logs when a link is removed.
- **Frontend Features**: Added Instagram profile support to the resume form and contact links. Implemented a toggle in the admin analytics dashboard to switch between 'Unique Visitors' and 'Total Views'.
- **Refactoring**: Standardized contact link handling by moving from individual properties to a `links` array, improving maintainability and type safety.
- **Testing**: Added new E2E tests for the analytics toggle and resume form, and updated existing tests to reflect the new data structure.

*Generated by Google Gemini (gemini-3.1-flash-lite)*

<!-- AI_SUMMARY_END -->