### PR TITLE
fix(web): refresh router after profile save and activation

### DIFF
--- a/apps/web/src/app/admin/resume/page.tsx
+++ b/apps/web/src/app/admin/resume/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, startTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseBrowser";
@@ -83,7 +83,9 @@ export default function ResumeProfilesPage() {
       }
 
       await loadProfiles();
-      router.refresh();
+      startTransition(() => {
+        router.refresh();
+      });
     } catch (err: any) {
       setErrorMsg(err.message || "Failed to activate resume profile.");
     } finally {

--- a/apps/web/src/app/admin/resume/page.tsx
+++ b/apps/web/src/app/admin/resume/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseBrowser";
 import { 
   UserSquare, 
@@ -23,6 +24,7 @@ interface Profile {
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:5808";
 
 export default function ResumeProfilesPage() {
+  const router = useRouter();
   const [profiles, setProfiles] = useState<Profile[]>([]);
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
@@ -81,6 +83,7 @@ export default function ResumeProfilesPage() {
       }
 
       await loadProfiles();
+      router.refresh();
     } catch (err: any) {
       setErrorMsg(err.message || "Failed to activate resume profile.");
     } finally {

--- a/apps/web/src/hooks/useResumeForm.ts
+++ b/apps/web/src/hooks/useResumeForm.ts
@@ -380,8 +380,8 @@ export function useResumeForm() {
     try {
       await saveProfile(profileId, payload);
       setSuccessMsg("Profile details saved successfully!");
+      router.refresh();
       setTimeout(() => {
-        router.refresh();
         router.push("/admin/resume");
       }, 1500);
     } catch (err: any) {

--- a/apps/web/src/hooks/useResumeForm.ts
+++ b/apps/web/src/hooks/useResumeForm.ts
@@ -381,6 +381,7 @@ export function useResumeForm() {
       await saveProfile(profileId, payload);
       setSuccessMsg("Profile details saved successfully!");
       setTimeout(() => {
+        router.refresh();
         router.push("/admin/resume");
       }, 1500);
     } catch (err: any) {


### PR DESCRIPTION
Fixes a bug where UI elements (like the profile picture and link visibility in the header) do not update without a hard refresh after saving or activating a resume profile. Added `router.refresh()` to properly invalidate the Next.js Client Router Cache and fetch fresh data.

<!-- AI_SUMMARY_START -->
### 🤖 AI-Generated Summary

This PR updates the resume management workflow in the admin dashboard to ensure consistent data synchronization between the client and server.

### Changelog
- **apps/web/src/app/admin/resume/page.tsx**: Wrapped `router.refresh()` in `startTransition` to prevent UI blocking during revalidation.
- **apps/web/src/hooks/useResumeForm.ts**: Refactored `router.refresh()` to execute immediately before navigation, mitigating potential race conditions associated with `setTimeout`.

*Generated by Google Gemini (gemini-3.1-flash-lite)*

<!-- AI_SUMMARY_END -->