### PR TITLE
fix(api): refactor Gemini stream parsing to use SSE format

### DIFF
--- a/apps/api/src/Portfolio.Infrastructure/AI/GeminiChatService.cs
+++ b/apps/api/src/Portfolio.Infrastructure/AI/GeminiChatService.cs
@@ -50,7 +50,7 @@ public class GeminiChatService : IAiChatService
             throw new InvalidOperationException("GEMINI_API_KEY is not configured in the environment variables.");
         }
 
-        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{_model}:streamGenerateContent?key={_apiKey}";
+        var url = $"https://generativelanguage.googleapis.com/v1beta/models/{_model}:streamGenerateContent?key={_apiKey}&alt=sse";
 
         var requestBody = new
         {
@@ -98,68 +98,36 @@ public class GeminiChatService : IAiChatService
         using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
         using var reader = new StreamReader(stream);
         
-        // Gemini stream returns an array of JSON objects via Server-Sent Events (but technically it's a JSON array format chunked)
-        // Wait, Gemini Developer API streamGenerateContent returns JSON chunks that look like:
-        // [
-        //   { "candidates": [ ... ] },
-        //   { "candidates": [ ... ] }
-        // ]
-        // but sent chunk by chunk over the HTTP response stream.
-
-        // We can just read the stream chunk by chunk and do some naive parsing to find the text parts.
-        // A more robust approach parses the JSON properly, but since chunks might be partial strings, we buffer them.
-        
-        var buffer = new StringBuilder();
-        
         string? line;
         while ((line = await reader.ReadLineAsync(cancellationToken)) != null)
         {
             if (string.IsNullOrWhiteSpace(line)) continue;
+            if (!line.StartsWith("data: ")) continue;
             
-            buffer.AppendLine(line);
-            var bufferStr = buffer.ToString();
+            var json = line.Substring("data: ".Length).Trim();
+            if (json == "[DONE]") break;
             
-            // Try to extract the "text": "..." part
-            // It's safer to attempt to parse valid JSON objects if the buffer contains balanced braces.
-            // For simplicity and speed in this naive implementation, we'll look for the text field in the raw string.
-            // In a production app, we should use System.Text.Json.Utf8JsonReader.
-            
-            // For now, let's implement a clean JSON parsing of the chunks.
-            // Gemini stream output usually separates chunks with commas, inside a global array.
-            
-            // Let's just grab the text values robustly
-            // This is a naive regex-like search that's very fast, but for production we should parse the JSON token.
             string? extractedText = null;
             try
             {
-                if (bufferStr.Trim().StartsWith("{") && bufferStr.Trim().EndsWith("}") || 
-                    bufferStr.Trim().StartsWith("{") && bufferStr.Trim().EndsWith("},"))
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("candidates", out var candidates) && candidates.GetArrayLength() > 0)
                 {
-                    var cleanJson = bufferStr.Trim();
-                    if (cleanJson.EndsWith(",")) cleanJson = cleanJson[..^1]; // remove trailing comma
-                    
-                    using var doc = JsonDocument.Parse(cleanJson);
-                    if (doc.RootElement.TryGetProperty("candidates", out var candidates) && candidates.GetArrayLength() > 0)
+                    var firstCandidate = candidates[0];
+                    if (firstCandidate.TryGetProperty("content", out var content) &&
+                        content.TryGetProperty("parts", out var parts) && parts.GetArrayLength() > 0)
                     {
-                        var firstCandidate = candidates[0];
-                        if (firstCandidate.TryGetProperty("content", out var content) &&
-                            content.TryGetProperty("parts", out var parts) && parts.GetArrayLength() > 0)
+                        var textPart = parts[0];
+                        if (textPart.TryGetProperty("text", out var textToken))
                         {
-                            var textPart = parts[0];
-                            if (textPart.TryGetProperty("text", out var textToken))
-                            {
-                                extractedText = textToken.GetString();
-                            }
+                            extractedText = textToken.GetString();
                         }
                     }
-                    
-                    // Reset buffer after successful parse
-                    buffer.Clear();
                 }
             }
             catch (JsonException)
             {
-                // Incomplete JSON chunk, keep buffering
+                // Incomplete or malformed JSON chunk, ignore
             }
 
             if (!string.IsNullOrEmpty(extractedText))


### PR DESCRIPTION
Fixes a bug where the backend failed to buffer and parse the default JSON array streaming from Gemini API. Appending `alt=sse` to the endpoint ensures standard Server-Sent Events output, enabling clean, line-by-line chunk parsing.

<!-- AI_SUMMARY_START -->
### 🤖 AI-Generated Summary

This PR updates the `GeminiChatService` to correctly handle Server-Sent Events (SSE) from the Google Gemini API. 

### Changelog
- Updated the API request URL to include `alt=sse` for standard SSE compliance.
- Refactored the stream processing logic to properly parse `data: ` prefixed lines instead of attempting to parse a malformed JSON array.
- Improved robustness by using `System.Text.Json.JsonDocument` to parse individual SSE chunks, ensuring cleaner resource management and error handling.

*Generated by Google Gemini (gemini-3.1-flash-lite)*

<!-- AI_SUMMARY_END -->