### PR TITLE
feat(resume): implement profile deletion and refine UI accents

### DIFF
--- a/apps/api/src/Portfolio.Tests/Integration/ResumeIntegrationTests.cs
+++ b/apps/api/src/Portfolio.Tests/Integration/ResumeIntegrationTests.cs
@@ -123,4 +123,60 @@ public class ResumeIntegrationTests
             await cleanupContext.SaveChangesAsync();
         }
     }
+    [Fact]
+    public async Task DeleteProfileEndpoint_DeletesSuccessfully()
+    {
+        // Arrange
+        using var scope = _fixture.Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<PortfolioDbContext>();
+
+        var p = new ResumeProfile { Id = Guid.NewGuid(), Name = "Profile to Delete", IsActive = false, Title = "Dev", Intro = "A" };
+        context.ResumeProfiles.Add(p);
+        await context.SaveChangesAsync();
+
+        // Act
+        var response = await _client.DeleteAsync($"/api/resume/{p.Id}");
+
+        // Assert
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.NoContent);
+
+        using var checkScope = _fixture.Factory.Services.CreateScope();
+        var checkContext = checkScope.ServiceProvider.GetRequiredService<PortfolioDbContext>();
+        var deletedProfile = await checkContext.ResumeProfiles.FindAsync(p.Id);
+        deletedProfile.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task DeleteProfileEndpoint_ReturnsBadRequest_ForActiveProfile()
+    {
+        // Arrange
+        using var scope = _fixture.Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<PortfolioDbContext>();
+
+        // Clean up existing to safely insert an active profile
+        context.ResumeProfiles.RemoveRange(context.ResumeProfiles);
+        await context.SaveChangesAsync();
+
+        var p = new ResumeProfile { Id = Guid.NewGuid(), Name = "Active Profile to Delete", IsActive = true, Title = "Dev", Intro = "A" };
+        context.ResumeProfiles.Add(p);
+        await context.SaveChangesAsync();
+
+        // Act
+        var response = await _client.DeleteAsync($"/api/resume/{p.Id}");
+
+        // Assert
+        response.StatusCode.ShouldBe(System.Net.HttpStatusCode.BadRequest);
+        var content = await response.Content.ReadAsStringAsync();
+        content.ShouldContain("Cannot delete the currently active profile");
+        
+        // Clean up
+        using var cleanupScope = _fixture.Factory.Services.CreateScope();
+        var cleanupContext = cleanupScope.ServiceProvider.GetRequiredService<PortfolioDbContext>();
+        var toRemove = await cleanupContext.ResumeProfiles.FindAsync(p.Id);
+        if (toRemove != null)
+        {
+            cleanupContext.ResumeProfiles.Remove(toRemove);
+            await cleanupContext.SaveChangesAsync();
+        }
+    }
 }

--- a/apps/api/src/Portfolio.Tests/Portfolio.Tests.csproj
+++ b/apps/api/src/Portfolio.Tests/Portfolio.Tests.csproj
@@ -6,7 +6,8 @@
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
         <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-        <Exclude>[Portfolio.Tests]*,[Portfolio.Faker]*,[Portfolio.Infrastructure]Portfolio.Infrastructure.Migrations.*,[Portfolio.Api]Program*,[Portfolio.Api]Microsoft.AspNetCore.OpenApi.Generated.*,[Portfolio.Api]System.Runtime.CompilerServices.*</Exclude>
+        <Exclude>[Portfolio.Tests]*,[Portfolio.Faker]*,[Portfolio.Infrastructure]Portfolio.Infrastructure.Migrations.*,[Portfolio.Api]Program*,[Portfolio.Api]*OpenApi*,[Portfolio.Api]System.Runtime.CompilerServices.*</Exclude>
+        <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
         <ExcludeByFile>**/Program.cs</ExcludeByFile>
     </PropertyGroup>
 

--- a/apps/api/src/Portfolio.Tests/Unit/Api/Analytics/Controllers/AnalyticsControllerTests.cs
+++ b/apps/api/src/Portfolio.Tests/Unit/Api/Analytics/Controllers/AnalyticsControllerTests.cs
@@ -1,0 +1,134 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Portfolio.Api.Analytics.Controllers;
+using Portfolio.Application.Analytics.Services;
+using Portfolio.Domain.Analytics;
+using Shouldly;
+using Xunit;
+
+namespace Portfolio.Tests.Unit.Api.Analytics.Controllers;
+
+public class AnalyticsControllerTests
+{
+    private readonly IAnalyticsService _analyticsServiceMock;
+    private readonly AnalyticsController _controller;
+    private readonly DefaultHttpContext _httpContext;
+
+    public AnalyticsControllerTests()
+    {
+        _analyticsServiceMock = Substitute.For<IAnalyticsService>();
+        _httpContext = new DefaultHttpContext();
+
+        _controller = new AnalyticsController(_analyticsServiceMock)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = _httpContext
+            }
+        };
+    }
+
+    [Fact]
+    public async Task LogPageViewAsync_WithValidRequest_ReturnsOk()
+    {
+        var sessionId = Guid.NewGuid();
+        _analyticsServiceMock
+            .GetOrCreateVisitorSessionAsync(Arg.Any<string>())
+            .Returns(new VisitorSession { Id = sessionId });
+
+        _httpContext.Request.Headers["User-Agent"] = "TestAgent";
+        
+        var request = new PageViewRequest
+        {
+            PagePath = "/test",
+            Country = "US",
+            City = "New York"
+        };
+
+        var result = await _controller.LogPageViewAsync(request);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.Value.ShouldNotBeNull();
+        
+        await _analyticsServiceMock.Received(1).LogPageViewAsync(Arg.Is<PageViewLog>(l => 
+            l.VisitorSessionId == sessionId && 
+            l.PagePath == "/test" && 
+            l.Country == "US"));
+    }
+
+    [Fact]
+    public async Task LogLinkClickAsync_WithValidRequest_ReturnsOk()
+    {
+        var sessionId = Guid.NewGuid();
+        var linkId = Guid.NewGuid();
+        _analyticsServiceMock
+            .GetOrCreateVisitorSessionAsync(Arg.Any<string>())
+            .Returns(new VisitorSession { Id = sessionId });
+
+        _httpContext.Request.Headers["User-Agent"] = "TestAgent";
+        
+        var request = new LinkClickRequest
+        {
+            LinkId = linkId,
+            Country = "US",
+            City = "New York"
+        };
+
+        var result = await _controller.LogLinkClickAsync(request);
+
+        var okResult = result.ShouldBeOfType<OkObjectResult>();
+        okResult.Value.ShouldNotBeNull();
+        
+        await _analyticsServiceMock.Received(1).LogLinkClickAsync(Arg.Is<LinkClickLog>(l => 
+            l.VisitorSessionId == sessionId && 
+            l.LinkId == linkId && 
+            l.Country == "US"));
+    }
+    
+    [Fact]
+    public async Task LogLinkClickAsync_WithEmptyLinkId_ReturnsBadRequest()
+    {
+        var request = new LinkClickRequest
+        {
+            LinkId = Guid.Empty
+        };
+
+        var result = await _controller.LogLinkClickAsync(request);
+
+        var badRequestResult = result.ShouldBeOfType<BadRequestObjectResult>();
+        badRequestResult.Value.ShouldBe("LinkId is required");
+    }
+
+    [Theory]
+    [InlineData("X-Forwarded-For", "192.168.1.1, 10.0.0.1", "192.168.1.1")]
+    [InlineData("X-Real-IP", "10.0.0.1", "10.0.0.1")]
+    public async Task LogPageViewAsync_ExtractsIpCorrectly(string headerName, string headerValue, string expectedIpHashBase)
+    {
+        var sessionId = Guid.NewGuid();
+        _analyticsServiceMock
+            .GetOrCreateVisitorSessionAsync(Arg.Any<string>())
+            .Returns(new VisitorSession { Id = sessionId });
+
+        _httpContext.Request.Headers[headerName] = headerValue;
+        _httpContext.Request.Headers["User-Agent"] = "TestAgent";
+        
+        var request = new PageViewRequest { PagePath = "/test" };
+
+        await _controller.LogPageViewAsync(request);
+
+        await _analyticsServiceMock.Received(1).GetOrCreateVisitorSessionAsync(Arg.Is<string>(id => id.Length == 64));
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ReturnsSummaryDto()
+    {
+        var summaryDto = new AnalyticsSummaryDto();
+        _analyticsServiceMock.GetSummaryAsync(20).Returns(summaryDto);
+
+        var result = await _controller.GetSummaryAsync(20);
+
+        var okResult = result.Result.ShouldBeOfType<OkObjectResult>();
+        okResult.Value.ShouldBe(summaryDto);
+    }
+}

--- a/apps/api/src/Portfolio.Tests/Unit/Infrastructure/AI/JobDescriptionExtractionServiceTests.cs
+++ b/apps/api/src/Portfolio.Tests/Unit/Infrastructure/AI/JobDescriptionExtractionServiceTests.cs
@@ -59,6 +59,19 @@ public class JobDescriptionExtractionServiceTests
         // Act & Assert
         await Should.ThrowAsync<ArgumentException>(() => _service.ExtractJobDescriptionAsync(request));
     }
+    
+    [Fact]
+    public async Task ExtractJobDescriptionAsync_WithValidUrl_ReturnsContent()
+    {
+        // Arrange
+        var request = new JobFitUploadRequest { Url = "http://example.com/job.txt" };
+
+        // Act
+        var result = await _service.ExtractJobDescriptionAsync(request);
+
+        // Assert
+        result.ShouldBe("Mocked Response Content");
+    }
 
     [Fact]
     public async Task ExtractJobDescriptionAsync_WithNoSource_ThrowsArgumentException()

--- a/apps/api/src/Portfolio.Tests/coverlet.runsettings
+++ b/apps/api/src/Portfolio.Tests/coverlet.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[Portfolio.Api]Microsoft.AspNetCore.OpenApi.*</Exclude>
+          <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/apps/web/e2e/admin.spec.ts
+++ b/apps/web/e2e/admin.spec.ts
@@ -128,4 +128,43 @@ test.describe('Admin Control Panel', () => {
     await expect(page.locator('#contact-links-section a[href="mailto:playwright-test@ajx.codes"]')).toBeAttached();
     await expect(page.locator('#contact-links-section a[href="https://instagram.com/playwright"]')).toBeAttached();
   });
+  test('should create and delete a resume profile', async ({ page }) => {
+    // 1. Navigate to resume profile list
+    await page.goto('/admin/resume');
+
+    // 2. Click "New Profile" and wait for navigation
+    await Promise.all([
+      page.waitForURL('**/admin/resume/form*'),
+      page.locator('text=New Profile').click()
+    ]);
+    await expect(page).toHaveURL(/\/admin\/resume\/form/);
+
+    // 3. Fill in Personal Info
+    const testName = `Delete Test Profile ${Date.now()}`;
+    await page.locator('#name').fill(testName);
+    await page.locator('#title').fill('Delete Candidate');
+    await page.locator('#intro').fill('This profile will be deleted.');
+
+    // 4. Save the profile
+    await page.locator('button[type="submit"]').first().click();
+
+    // Verify success banner and wait for auto-redirect back to list
+    const successBanner = page.locator('text=Profile details saved successfully!');
+    await expect(successBanner).toBeVisible({ timeout: 15000 });
+    await expect(page).toHaveURL(/\/admin\/resume/, { timeout: 15000 });
+
+    // 5. Find the newly created profile card and click "Delete"
+    const profileCard = page.locator('div.terminal-card', { hasText: testName });
+    await expect(profileCard).toBeVisible();
+    
+    const deleteButton = profileCard.locator('button:has-text("Delete")');
+    await deleteButton.click();
+
+    // 6. Confirm the deletion dialog
+    const confirmButton = page.locator('button:has-text("Confirm Delete")');
+    await confirmButton.click();
+
+    // Verify the profile is removed
+    await expect(profileCard).not.toBeVisible();
+  });
 });

--- a/apps/web/src/app/admin/blog/page.tsx
+++ b/apps/web/src/app/admin/blog/page.tsx
@@ -238,7 +238,7 @@ export default function AdminBlogPage() {
                 type="button"
                 onClick={() => handleDelete(postToDelete.id)}
                 disabled={deleteLoading === postToDelete.id}
-                className="px-4 py-2 bg-destructive text-destructive-foreground hover:bg-destructive/90 text-sm font-bold rounded transition-all disabled:opacity-50"
+                className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 text-sm font-bold rounded transition-all disabled:opacity-50"
               >
                 {deleteLoading === postToDelete.id ? "Deleting..." : "Confirm Delete"}
               </button>

--- a/apps/web/src/app/admin/resume/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/resume/__tests__/page.test.tsx
@@ -220,4 +220,60 @@ describe('ResumeProfilesPage', () => {
       expect(screen.getByText(/Failed to load profiles/i)).toBeInTheDocument();
     });
   });
+
+  it('displays error when activating a profile fails', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options && options.method === 'POST' && url.includes('/activate')) {
+        return Promise.resolve({ ok: false, status: 500, text: () => Promise.resolve('Error activating') });
+      }
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockProfiles)
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    const activateButton = screen.getByRole('button', { name: /Activate/i });
+    fireEvent.click(activateButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error activating/i)).toBeInTheDocument();
+    });
+  });
+
+  it('fetches with authorization header when session exists', async () => {
+    // Mock the session for this test only
+    const { supabase } = require('@/lib/supabaseBrowser');
+    supabase.auth.getSession.mockResolvedValueOnce({ 
+      data: { session: { access_token: 'mock-token' } } 
+    });
+
+    mockFetch.mockImplementation((url, options) => {
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockProfiles) });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/resume'),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer mock-token'
+          })
+        })
+      );
+    });
+  });
 });

--- a/apps/web/src/app/admin/resume/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/resume/__tests__/page.test.tsx
@@ -276,4 +276,40 @@ describe('ResumeProfilesPage', () => {
       );
     });
   });
+
+  it('traps focus inside the modal when pressing Tab', async () => {
+    mockFetch.mockImplementation((url) => {
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockProfiles) });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    // Open modal
+    const deleteButton = screen.getByRole('button', { name: /Delete/i });
+    fireEvent.click(deleteButton);
+
+    const cancelButton = await screen.findByRole('button', { name: /Cancel/i });
+    const confirmButton = screen.getByRole('button', { name: /Confirm Delete/i });
+
+    // Focus first element initially (Cancel button usually, or whatever is first)
+    cancelButton.focus();
+    expect(document.activeElement).toBe(cancelButton);
+
+    // Simulate Tab on last element to wrap to first
+    confirmButton.focus();
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+    expect(document.activeElement).toBe(cancelButton);
+
+    // Simulate Shift+Tab on first element to wrap to last
+    cancelButton.focus();
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(confirmButton);
+  });
 });

--- a/apps/web/src/app/admin/resume/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/resume/__tests__/page.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import ResumeProfilesPage from '../page';
+
+jest.mock('lucide-react', () => ({
+  UserSquare: () => <div data-testid="user-square-icon" />,
+  Plus: () => <div data-testid="plus-icon" />,
+  CheckCircle2: () => <div data-testid="check-circle2-icon" />,
+  AlertCircle: () => <div data-testid="alert-circle-icon" />,
+  Trash2: () => <div data-testid="trash-icon" />,
+}));
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('@/lib/supabaseBrowser', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } })
+    }
+  }
+}));
+
+const mockProfiles = [
+  {
+    id: 'profile-1',
+    name: 'Active Profile',
+    title: 'Senior Developer',
+    intro: 'Intro for active profile',
+    isActive: true,
+    updatedAt: '2024-01-01T12:00:00Z',
+  },
+  {
+    id: 'profile-2',
+    name: 'Inactive Profile',
+    title: 'Junior Developer',
+    intro: 'Intro for inactive profile',
+    isActive: false,
+    updatedAt: '2024-01-02T12:00:00Z',
+  }
+];
+
+describe('ResumeProfilesPage', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    mockFetch = jest.fn();
+    global.fetch = mockFetch;
+    
+    mockFetch.mockImplementation((url, options) => {
+      if (url.includes('/api/resume') && (!options || options.method === 'GET' || options.method === undefined)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockProfiles)
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the resume profiles list', async () => {
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Active Profile$/i })).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Senior Developer/i)).toBeInTheDocument();
+    expect(screen.getByText(/Junior Developer/i)).toBeInTheDocument();
+    
+    expect(screen.getByText(/New Profile/i)).toBeInTheDocument();
+  });
+
+  it('activates a profile', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options && options.method === 'POST' && url.includes('/activate')) {
+        return Promise.resolve({ ok: true });
+      }
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockProfiles)
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    const activateButton = screen.getByRole('button', { name: /Activate/i });
+    fireEvent.click(activateButton);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/resume/profile-2/activate'),
+        expect.objectContaining({ method: 'POST' })
+      );
+    });
+  });
+
+  it('deletes a profile when confirmed', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options && options.method === 'DELETE') {
+        return Promise.resolve({ ok: true });
+      }
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockProfiles)
+        });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Delete/i });
+    fireEvent.click(deleteButton);
+
+    const confirmButton = await screen.findByRole('button', { name: /Confirm Delete/i });
+    fireEvent.click(confirmButton);
+    
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/resume/profile-2'),
+        expect.objectContaining({ method: 'DELETE' })
+      );
+    });
+  });
+
+  it('cancels deletion when cancel is clicked', async () => {
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Delete/i });
+    fireEvent.click(deleteButton);
+
+    const cancelButton = await screen.findByRole('button', { name: /Cancel/i });
+    fireEvent.click(cancelButton);
+    
+    expect(screen.queryByText(/delete_profile/i)).not.toBeInTheDocument();
+  });
+
+  it('displays error message when delete fails', async () => {
+    mockFetch.mockImplementation((url, options) => {
+      if (options && options.method === 'DELETE') {
+        return Promise.resolve({ ok: false, text: () => Promise.resolve('Error deleting') });
+      }
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(mockProfiles) });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /^Inactive Profile$/i })).toBeInTheDocument();
+    });
+
+    const deleteButton = screen.getByRole('button', { name: /Delete/i });
+    fireEvent.click(deleteButton);
+
+    const confirmButton = await screen.findByRole('button', { name: /Confirm Delete/i });
+    fireEvent.click(confirmButton);
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Error deleting/i)).toBeInTheDocument();
+    });
+  });
+
+  it('displays empty state when no profiles', async () => {
+    mockFetch.mockImplementation((url) => {
+      if (url.includes('/api/resume')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByText(/No Profiles Configured/i)).toBeInTheDocument();
+    });
+  });
+
+  it('displays error when loading profiles fails', async () => {
+    mockFetch.mockImplementation(() => {
+      return Promise.resolve({ ok: false, status: 500 });
+    });
+
+    render(<ResumeProfilesPage />);
+    
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load profiles/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/admin/resume/page.tsx
+++ b/apps/web/src/app/admin/resume/page.tsx
@@ -34,6 +34,8 @@ export default function ResumeProfilesPage() {
   const [profileToDelete, setProfileToDelete] = useState<Profile | null>(null);
   const modalRef = useRef<HTMLDivElement>(null);
 
+  // Note: Consider migrating to a headless UI library like Radix UI for 
+  // more robust focus management and accessibility in the future.
   useEffect(() => {
     if (profileToDelete && modalRef.current) {
       const focusableElements = modalRef.current.querySelectorAll(
@@ -142,6 +144,8 @@ export default function ResumeProfilesPage() {
     setProfileToDelete(null);
 
     try {
+      // NOTE: Ensure API_BASE_URL is HTTPS in production.
+      // The Authorization header is strictly sent to the API and not logged.
       const headers = await fetchAuthHeaders();
       const res = await fetch(`${API_BASE_URL}/api/resume/${id}`, {
         method: "DELETE",

--- a/apps/web/src/app/admin/resume/page.tsx
+++ b/apps/web/src/app/admin/resume/page.tsx
@@ -8,7 +8,8 @@ import {
   UserSquare, 
   Plus, 
   CheckCircle2, 
-  AlertCircle
+  AlertCircle,
+  Trash2
 } from "lucide-react";
 import { AdminSkeleton } from "@/components/admin/AdminSkeleton";
 
@@ -29,6 +30,8 @@ export default function ResumeProfilesPage() {
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState("");
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState<string | null>(null);
+  const [profileToDelete, setProfileToDelete] = useState<Profile | null>(null);
 
   const fetchAuthHeaders = async () => {
     const headers: Record<string, string> = {
@@ -90,6 +93,34 @@ export default function ResumeProfilesPage() {
       setErrorMsg(err.message || "Failed to activate resume profile.");
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeleteLoading(id);
+    setErrorMsg("");
+    
+    // Optimistic UI Update
+    const previousProfiles = [...profiles];
+    setProfiles((prev) => prev.filter((p) => p.id !== id));
+    setProfileToDelete(null);
+
+    try {
+      const headers = await fetchAuthHeaders();
+      const res = await fetch(`${API_BASE_URL}/api/resume/${id}`, {
+        method: "DELETE",
+        headers,
+      });
+
+      if (!res.ok) {
+        const errorText = await res.text();
+        throw new Error(errorText || `Failed to delete profile (${res.status})`);
+      }
+    } catch (err: any) {
+      setProfiles(previousProfiles);
+      setErrorMsg(err.message || "Failed to delete resume profile.");
+    } finally {
+      setDeleteLoading(null);
     }
   };
 
@@ -181,18 +212,64 @@ export default function ResumeProfilesPage() {
                   </Link>
 
                   {!profile.isActive && (
-                    <button
-                      onClick={() => handleActivate(profile.id)}
-                      disabled={actionLoading !== null}
-                      className="px-3 py-1 bg-primary text-primary-foreground text-[10px] font-bold rounded transition-all disabled:opacity-50"
-                    >
-                      {actionLoading === profile.id ? "Activating..." : "Activate"}
-                    </button>
+                    <>
+                      <button
+                        onClick={() => handleActivate(profile.id)}
+                        disabled={actionLoading !== null}
+                        className="px-3 py-1 bg-primary text-primary-foreground text-[10px] font-bold rounded transition-all disabled:opacity-50"
+                      >
+                        {actionLoading === profile.id ? "Activating..." : "Activate"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setProfileToDelete(profile)}
+                        disabled={deleteLoading === profile.id}
+                        className="flex items-center gap-1 px-3 py-1 border border-destructive/20 text-destructive hover:bg-destructive/10 text-[10px] font-bold rounded transition-all disabled:opacity-50"
+                      >
+                        <Trash2 className="w-3 h-3" />
+                        {deleteLoading === profile.id ? "..." : "Delete"}
+                      </button>
+                    </>
                   )}
                 </div>
               </div>
             </div>
           ))}
+        </div>
+      )}
+
+      {/* Custom Delete Confirmation Dialog */}
+      {profileToDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+          <div className="terminal-card border border-destructive/20 bg-card w-full max-w-md p-6 rounded-xl shadow-2xl animate-in fade-in zoom-in duration-200">
+            <div className="flex items-center gap-3 mb-4">
+              <AlertCircle className="w-6 h-6 text-destructive" />
+              <h2 className="text-lg font-bold text-foreground font-mono">delete_profile</h2>
+            </div>
+            
+            <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+              Are you sure you want to delete <span className="text-foreground font-bold">"{profileToDelete.name}"</span>? This action is permanent and cannot be undone.
+            </p>
+
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setProfileToDelete(null)}
+                disabled={deleteLoading === profileToDelete.id}
+                className="px-4 py-2 border border-primary/20 text-foreground/80 hover:bg-primary/10 hover:text-foreground text-sm font-bold rounded transition-all disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => handleDelete(profileToDelete.id)}
+                disabled={deleteLoading === profileToDelete.id}
+                className="px-4 py-2 bg-primary text-primary-foreground hover:bg-primary/90 text-sm font-bold rounded transition-all disabled:opacity-50"
+              >
+                {deleteLoading === profileToDelete.id ? "Deleting..." : "Confirm Delete"}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/app/admin/resume/page.tsx
+++ b/apps/web/src/app/admin/resume/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, startTransition } from "react";
+import { useEffect, useState, useRef, startTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseBrowser";
@@ -32,6 +32,42 @@ export default function ResumeProfilesPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [deleteLoading, setDeleteLoading] = useState<string | null>(null);
   const [profileToDelete, setProfileToDelete] = useState<Profile | null>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (profileToDelete && modalRef.current) {
+      const focusableElements = modalRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableElements.length > 0) {
+        (focusableElements[0] as HTMLElement).focus();
+      }
+
+      const handleTabKey = (e: KeyboardEvent) => {
+        if (e.key === 'Tab') {
+          const firstElement = focusableElements[0] as HTMLElement;
+          const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+          if (e.shiftKey) {
+            if (document.activeElement === firstElement) {
+              e.preventDefault();
+              lastElement.focus();
+            }
+          } else {
+            if (document.activeElement === lastElement) {
+              e.preventDefault();
+              firstElement.focus();
+            }
+          }
+        }
+      };
+
+      document.addEventListener('keydown', handleTabKey);
+      return () => {
+        document.removeEventListener('keydown', handleTabKey);
+      };
+    }
+  }, [profileToDelete]);
 
   const fetchAuthHeaders = async () => {
     const headers: Record<string, string> = {
@@ -241,13 +277,20 @@ export default function ResumeProfilesPage() {
       {/* Custom Delete Confirmation Dialog */}
       {profileToDelete && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
-          <div className="terminal-card border border-destructive/20 bg-card w-full max-w-md p-6 rounded-xl shadow-2xl animate-in fade-in zoom-in duration-200">
+          <div 
+            ref={modalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-dialog-title"
+            aria-describedby="delete-dialog-description"
+            className="terminal-card border border-destructive/20 bg-card w-full max-w-md p-6 rounded-xl shadow-2xl animate-in fade-in zoom-in duration-200"
+          >
             <div className="flex items-center gap-3 mb-4">
               <AlertCircle className="w-6 h-6 text-destructive" />
-              <h2 className="text-lg font-bold text-foreground font-mono">delete_profile</h2>
+              <h2 id="delete-dialog-title" className="text-lg font-bold text-foreground font-mono">delete_profile</h2>
             </div>
             
-            <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+            <p id="delete-dialog-description" className="text-sm text-muted-foreground mb-6 leading-relaxed">
               Are you sure you want to delete <span className="text-foreground font-bold">"{profileToDelete.name}"</span>? This action is permanent and cannot be undone.
             </p>
 

--- a/apps/web/src/components/FloatingAiWidget.tsx
+++ b/apps/web/src/components/FloatingAiWidget.tsx
@@ -516,8 +516,8 @@ export function FloatingAiWidget({ blogPosts = [], resume }: FloatingAiWidgetPro
         <BotIcon className={`w-6 h-6 transition-transform duration-300 ${isOpen ? 'scale-0' : 'scale-100'}`} />
         <svg className={`w-6 h-6 absolute transition-transform duration-300 ${isOpen ? 'scale-100' : 'scale-0'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" /></svg>
         <span className="absolute -top-1 -right-1 flex h-3 w-3">
-          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"></span>
-          <span className="relative inline-flex rounded-full h-3 w-3 bg-white/90"></span>
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-300 opacity-75 dark:bg-white"></span>
+          <span className="relative inline-flex rounded-full h-3 w-3 bg-teal-200 dark:bg-white/90"></span>
         </span>
       </motion.button>
     </>

--- a/apps/web/src/components/ResumeClientPage.tsx
+++ b/apps/web/src/components/ResumeClientPage.tsx
@@ -188,21 +188,20 @@ export const ResumeClientPage = ({ resume, personalInfo }: ResumeClientPageProps
             <p className="text-balance">{personalInfo.intro}</p>
           </div>
           
-          {/* CTA Button is now ABOVE contact links */}
           <div ref={ctaRef} className="mt-6 flex justify-center md:justify-start">
             <div className="relative inline-flex group">
               {/* Glowing background effect tied to button size */}
-              <div className="absolute inset-0 bg-white blur-xl rounded-xl opacity-40 group-hover:opacity-60 transition-opacity duration-500 animate-pulse" style={{ animationDuration: '3s' }} />
+              <div className="absolute inset-0 bg-primary blur-xl rounded-xl opacity-40 group-hover:opacity-60 transition-opacity duration-500 animate-pulse" style={{ animationDuration: '3s' }} />
               
               <button
                 onClick={() => window.dispatchEvent(new CustomEvent('openAiWidget'))}
-                className="relative inline-flex items-center gap-3 px-6 py-3.5 font-semibold text-black bg-white rounded-xl overflow-hidden shadow-[0_0_20px_rgba(255,255,255,0.4)] hover:shadow-[0_0_30px_rgba(255,255,255,0.6)] transition-all duration-300 hover:-translate-y-1"
+                className="relative inline-flex items-center gap-3 px-6 py-3.5 font-semibold text-primary-foreground bg-primary rounded-xl overflow-hidden shadow-xl shadow-primary/30 hover:shadow-primary/50 transition-all duration-300 hover:-translate-y-1"
               >
                 {/* Shimmer effect on hover */}
-                <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-black/10 to-transparent group-hover:animate-[shimmer_1.5s_infinite]" />
+                <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-primary-foreground/10 to-transparent group-hover:animate-[shimmer_1.5s_infinite]" />
                 
-                <div className="relative z-10 bg-black/5 p-1.5 rounded-lg">
-                  <BotIcon className="w-5 h-5 animate-pulse text-black" style={{ animationDuration: '2s' }} />
+                <div className="relative z-10 bg-primary-foreground/10 p-1.5 rounded-lg">
+                  <BotIcon className="w-5 h-5 animate-pulse text-primary-foreground" style={{ animationDuration: '2s' }} />
                 </div>
                 
                 <TypewriterText />
@@ -210,8 +209,8 @@ export const ResumeClientPage = ({ resume, personalInfo }: ResumeClientPageProps
 
               {/* Notification dot placed OUTSIDE the overflow-hidden button */}
               <span className="absolute -top-1.5 -right-1.5 flex h-3.5 w-3.5 pointer-events-none transition-transform duration-300 group-hover:-translate-y-1">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75" style={{ animationDuration: '2s' }}></span>
-                <span className="relative inline-flex rounded-full h-3.5 w-3.5 bg-white shadow-[0_0_8px_white]"></span>
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-teal-300 opacity-75 dark:bg-white" style={{ animationDuration: '2s' }}></span>
+                <span className="relative inline-flex rounded-full h-3.5 w-3.5 bg-teal-200 shadow-[0_0_8px_theme(colors.teal.300)] dark:bg-white dark:shadow-[0_0_8px_white]"></span>
               </span>
             </div>
           </div>


### PR DESCRIPTION
closes #99

<!-- AI_SUMMARY_START -->
### 🤖 AI-Generated Summary

This PR introduces a robust deletion workflow for resume profiles, including backend integration tests, frontend UI components, and comprehensive unit testing for the new functionality. 

### Changelog
- **Backend**: Added `DeleteProfileEndpoint` logic and corresponding integration tests in `ResumeIntegrationTests.cs`.
- **Backend**: Added `AnalyticsController` unit tests and updated `coverlet.runsettings` for better coverage reporting.
- **Frontend**: Implemented a custom delete confirmation modal in `apps/web/src/app/admin/resume/page.tsx` with focus trapping.
- **Frontend**: Added unit tests for `ResumeProfilesPage` using `react-testing-library`.
- **Frontend**: Updated UI styling for the AI widget and CTA buttons to align with the primary theme.

*Generated by Google Gemini (gemini-3.1-flash-lite)*

<!-- AI_SUMMARY_END -->